### PR TITLE
fix: suppress bigint-buffer native binding warning

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+echo "🔧 Slashbot Build Script"
+echo "========================"
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+# Step 1: Install dependencies
+echo -e "\n${GREEN}[1/3]${NC} Installing dependencies..."
+bun install
+
+# Step 2: Type check
+echo -e "\n${GREEN}[2/3]${NC} Running type check..."
+if bun run typecheck; then
+    echo -e "${GREEN}✓${NC} Type check passed"
+else
+    echo -e "${RED}✗${NC} Type check failed"
+    exit 1
+fi
+
+# Step 3: Build standalone binary
+echo -e "\n${GREEN}[3/3]${NC} Compiling standalone binary..."
+bun build --compile --minify src/index.ts --outfile dist/slashbot
+
+echo -e "\n${GREEN}✓ Build complete!${NC}"
+echo "  Binary: dist/slashbot"

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,9 @@
  * A Claude Code-inspired terminal assistant using X.AI's Grok API.
  */
 
+// Must be first: suppress bigint-buffer native binding warning
+import './patches/suppress-bigint-warning';
+
 import {
   banner,
   inputPrompt,

--- a/src/patches/suppress-bigint-warning.ts
+++ b/src/patches/suppress-bigint-warning.ts
@@ -1,0 +1,19 @@
+/**
+ * Suppress the bigint-buffer native binding warning.
+ *
+ * This must be imported BEFORE any @solana packages.
+ * The warning occurs because Bun-compiled binaries cannot embed native .node addons.
+ * The pure JS fallback is fully functional.
+ */
+
+const originalWarn = console.warn;
+
+console.warn = (...args: unknown[]) => {
+  const message = args[0];
+  if (typeof message === 'string' && message.includes('bigint: Failed to load bindings')) {
+    return; // Suppress this specific warning
+  }
+  originalWarn.apply(console, args);
+};
+
+export {};


### PR DESCRIPTION
- Add build.sh script for consistent build process
- Create suppress-bigint-warning patch to filter console.warn
- Import patch at app entry point before Solana modules load